### PR TITLE
Feature: Allow drop folder(s)

### DIFF
--- a/src/DropAreaBase/DropAreaBase.js
+++ b/src/DropAreaBase/DropAreaBase.js
@@ -27,8 +27,8 @@ function cancelEvent (e) {
 // Declare global DataTransferItem for standardjs lintfix
 /* global DataTransferItem */
 
-// Browser supports webkitGetAsEntry API. Used for dropping folders
-const webkitGetAsEntrySupported = 'webkitGetAsEntry' in DataTransferItem.prototype
+// Browser supports webkitGetAsEntry API needed for dropping folders
+const folderDropSupported = !!DataTransferItem.prototype.webkitGetAsEntry
 
 export default class DropAreaBase extends React.Component {
   fileInputRef = React.createRef()
@@ -101,7 +101,7 @@ export default class DropAreaBase extends React.Component {
     }
 
     if (this.isAcceptingTransfer(e.dataTransfer)) {
-      if (webkitGetAsEntrySupported === false) {
+      if (folderDropSupported === false) {
         this.props.onSelectFiles(e.dataTransfer.files)
       } else {
         // Recursive function to walk into directories and extract file objects

--- a/src/DropAreaBase/DropAreaBase.js
+++ b/src/DropAreaBase/DropAreaBase.js
@@ -24,6 +24,12 @@ function cancelEvent (e) {
   e.stopPropagation()
 }
 
+// Declare global DataTransferItem for standardjs lintfix
+/* global DataTransferItem */
+
+// Browser supports webkitGetAsEntry API. Used for dropping folders
+const webkitGetAsEntrySupported = 'webkitGetAsEntry' in DataTransferItem.prototype
+
 export default class DropAreaBase extends React.Component {
   fileInputRef = React.createRef()
 
@@ -95,12 +101,9 @@ export default class DropAreaBase extends React.Component {
     }
 
     if (this.isAcceptingTransfer(e.dataTransfer)) {
-      if (e.dataTransfer.items.length === 0 || e.dataTransfer.items[0].webkitGetAsEntry === undefined) {
-        // Browser does not support webkitGetAsEntry.
+      if (webkitGetAsEntrySupported === false) {
         this.props.onSelectFiles(e.dataTransfer.files)
       } else {
-        // Browser supports webkitGetAsEntry (needed when dirs are in dropped items)
-
         // Recursive function to walk into directories and extract file objects
         const recurseItem = (item, sub) => new Promise((resolve, reject) => {
           // Resolve with a single item list


### PR DESCRIPTION
This feature allows the DropAreaBase to accept folders as well. Folder(s) will be recursively scanned and the files within will be collected into a flat array. The file array is passed on to `onSelectFiles`

Tested on

- Firefox 80.0.1 (64-bit/Linux Ubuntu 16.04) 
- Chrome 83.0.4103.97 (Official Build) (64-bit/Linux Ubuntu 16.04)

Resolves #1 